### PR TITLE
I am not even sure this will work:

### DIFF
--- a/tablesnap
+++ b/tablesnap
@@ -186,6 +186,8 @@ class UploadHandler(pyinotify.ProcessEvent):
                     raise
 
                 md5 = key.compute_md5(fp)
+#               Return the cursor to the beginning of the file
+                fp.seek(0)
                 fp.close()
                 self.log.debug('Computed md5: %s' % (md5,))
 
@@ -282,6 +284,8 @@ class UploadHandler(pyinotify.ProcessEvent):
         else:
             fp = open(filename, 'rb')
             md5 = boto.utils.compute_md5(fp)
+#           Return cursor to the beginning of the file
+            fp.seek(0)
             self.log.debug('Computed md5sum before upload is: %s' % (md5,))
             fp.close()
 


### PR DESCRIPTION
Everything seems to indicate I am computing the md5 in the right way,
several search results suggest most of the times this error is due to
people doing their own computation instead of relying on the tested and
true `boto.utils.compute_md5()`, but I am actually doing that. some
other people have the same issue when reading the file beforehand and
then computing the md5, this moves the cursor to the end (or whatever
position) of the file and making the md5 not work. So for the sake of
ruling this out, here it is.
