### PR TITLE
Add dry run, support large buckets

### DIFF
--- a/tableslurp
+++ b/tableslurp
@@ -65,6 +65,7 @@ class DownloadHandler(object):
     prefix = None
     force = False
     global_index = False
+    dry_run = False
     name = socket.getfqdn()
     fileset = []
     queue = Queue()
@@ -81,6 +82,7 @@ class DownloadHandler(object):
         self.num_threads = args.threads
         self.force = args.force
         self.global_index = args.global_index
+        self.dry_run = args.dry_run
         if args.name:
             self.name = args.name
         self.prefix = '%s:%s' % (self.name, self.origin)
@@ -123,12 +125,15 @@ class DownloadHandler(object):
 #       Otherwise try to fetch the most recent one
         else:
             log.debug('Getting all keys for %s/*%s' % (self.prefix, index_suffix))
-            keys = [_ for _ in bucket.get_all_keys(prefix='%s/' %
-                (self.prefix,)) if _.name.endswith(index_suffix)]
+            all_keys = bucket.list(prefix='%s/' % (self.prefix,))
+            keys = [_ for _ in all_keys if _.name.endswith(index_suffix)]
+            log.debug('Length of keys: %s' % (len(keys),))
             if keys:
                 keys.sort(key=lambda l: parser.parse(l.last_modified))
                 key = keys.pop()
                 log.debug('Latest key is %s' % (key.name,))
+            else:
+                raise LookupError("Couldn't find any keys at %s/" % (self.prefix,))
 
         if not key:
             raise LookupError('Cannot find anything to restore from %s:%s/%s' %
@@ -217,15 +222,20 @@ class DownloadHandler(object):
                         download = True
 
                     if download:
-                        log.debug('Creating dir %s' % (os.path.dirname(destfile)))
-                        try:
-                            os.makedirs(os.path.dirname(destfile))
-                        except OSError as exc:
-                            if exc.errno == errno.EEXIST:
-                                pass
-                        log.info('Downloading %s from %s to %s' %
-                            (key.name, bucket.name, destfile))
-                        key.get_contents_to_filename(destfile)
+                        if self.dry_run:
+                            log.debug('Not creating dir %s' % (os.path.dirname(destfile)))
+                            log.info('Not downloading %s from %s to %s' %
+                                (key.name, bucket.name, destfile))
+                        else:
+                            log.debug('Creating dir %s' % (os.path.dirname(destfile)))
+                            try:
+                                os.makedirs(os.path.dirname(destfile))
+                            except OSError as exc:
+                                if exc.errno == errno.EEXIST:
+                                    pass
+                            log.info('Downloading %s from %s to %s' %
+                                (key.name, bucket.name, destfile))
+                            key.get_contents_to_filename(destfile)
 
                 except Exception as e:
                     log.debug(e)
@@ -300,6 +310,8 @@ def main():
     ap.add_argument('--global-index', default=False, action='store_true',
         help='Use a global index to retrieve all files from all backed'
         ' up directories. This is useful for multi-datadir (JBOD) cassandra')
+    ap.add_argument('--dry-run', default=False, action='store_true',
+        help='Don\'t actually download any files, just verify they\'re available')
     ap.add_argument('-n', '--name', default=socket.getfqdn(),
         help='Use this name instead of the FQDN to prefix the bucket dir')
     ap.add_argument('bucket', nargs=1,

--- a/tablesnap
+++ b/tablesnap
@@ -310,8 +310,8 @@ class UploadHandler(pyinotify.ProcessEvent):
                 file_list = []
                 for path in self.paths:
                     for root, dirs, files in os.walk(path):
-                        for file in files:
-                            fn = os.path.join(root, file)
+                        for targetfile in files:
+                            fn = os.path.join(root, targetfile)
                             if self.include is None or self.include(fn):
                                 file_list.append(fn)
                 index_name = '%s-global-index.txt' % keyname


### PR DESCRIPTION
- --dry-run for tableslurp so you can actually kind of test backups
- Previously if your bucket prefix had >1000 keys, you would not restore
  the latest backup using auto-mode
- Add some debugging

Known bugs:
- Include/exclude is applied against full paths for the backup, but only
  the basename for restores, if you're not using --global-index
- With --global-index, you have to restore the entire backup, where
  having the ability to restore a single table should be possible (but
  semi-complicated). Maybe something like --include for tableslurp.
